### PR TITLE
WIP: Add city pages, enable direct linking

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,5 @@
+// hacks for skipping scroll on navigation
+const { DO_NOT_SCROLL_KEY } = require('./gatsby-constants')
+
+exports.shouldUpdateScroll = () => !window[DO_NOT_SCROLL_KEY]
+exports.onRouteUpdate = () => delete window[DO_NOT_SCROLL_KEY]

--- a/gatsby-constants.js
+++ b/gatsby-constants.js
@@ -1,0 +1,1 @@
+exports.DO_NOT_SCROLL_KEY = '__doNotScroll'

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,16 @@
+const { resolve } = require('path')
+const { createCityUrl, unwrapNodes } = require('./src/utils')
+
+exports.createPages = async ({ graphql, actions: { createPage } }) => {
+  const { data: { allCitiesJson } } = await graphql(`{
+    allCitiesJson { edges { node { country slug } } }
+  }`)
+
+  const cities = unwrapNodes(allCitiesJson)
+
+  cities.forEach(({ country, slug }) => createPage({
+    path: createCityUrl(country, slug),
+    context: { country, slug },
+    component: resolve('./src/pages/index.js'),
+  }))
+}

--- a/src/components/CityLink.js
+++ b/src/components/CityLink.js
@@ -1,0 +1,32 @@
+// Libraries
+import React, { forwardRef } from 'react'
+import { Link } from 'gatsby'
+
+// Utilities
+import { createCityUrl, navigateTo } from '../utils'
+
+const handleClick = event => {
+  if (event.ctrlKey || event.metaKey) return
+  event.preventDefault()
+  return navigateTo(
+    event.target.getAttribute('href'),
+    { top: 850, behavior: 'smooth' },
+  )
+}
+
+const allowedProps = ['to', 'style', 'className', 'children', 'tabIndex']
+const pass = input => allowedProps.reduce((output, key) => {
+  if (input[key] !== undefined) output[key] = input[key]
+  return output
+},{})
+
+const CityLink = forwardRef(({ country, slug, ...props }, ref) => (
+  <Link
+    ref={ref}
+    to={createCityUrl(country, slug)}
+    onClick={handleClick}
+    {...pass(props)}
+  />
+))
+
+export default CityLink

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -5,6 +5,9 @@ import styled from 'styled-components'
 import Rellax from 'rellax'
 import Tippy from '@tippy.js/react'
 
+// Components
+import CityLink from './CityLink'
+
 // Illustration
 import MapIllustration from '../svgs/map.svg'
 import BackgroundIllustration from '../svgs/background.svg'
@@ -19,18 +22,13 @@ import YellowBall from '../svgs/yellow-ball.svg'
 Tippy.defaultProps = { ...Tippy.defaultProps, a11y: false }
 
 // Map
-const Map = ({ setCurrentCity }) => {
+const Map = () => {
 
   const data = useStaticQuery(citiesQuery)
   const cities = data.allCitiesJson.edges
 
   useEffect(() => { new Rellax('.rellax') }, [])
-
-  const handleDotClick = city => {
-    window.scrollTo({ top: 850, behavior: 'smooth' })
-    setCurrentCity({ label: city.name, value: city.slug })
-  }
-
+  
   return (
     <Container>
       <Title className="rellax" data-rellax-speed="-5">
@@ -40,7 +38,7 @@ const Map = ({ setCurrentCity }) => {
       <Dots className="rellax" data-rellax-speed="-4">
         { cities.map(({ node: city }) =>
           <Tippy content={city.name} key={city.id}>
-            <Dot {...city} onClick={() => handleDotClick(city)} />
+            <Dot {...city} tabIndex={-1} />
           </Tippy>
         )}
       </Dots>
@@ -159,7 +157,8 @@ const Dots = styled.div`
   @media screen and (min-width: 1100px) { left: 60px; }
 `
 
-const Dot = styled.div`
+const Dot = styled(CityLink)`
+  display: block;
   transition: transform 0.1s ease, opacity 0.1s ease;
   position: absolute;
   z-index: 5;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -159,6 +159,7 @@ const Dots = styled.div`
 
 const Dot = styled(CityLink)`
   display: block;
+  outline: none;
   transition: transform 0.1s ease, opacity 0.1s ease;
   position: absolute;
   z-index: 5;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,10 @@
 // Libraries
-import React, { useState } from 'react'
+import React from 'react'
+import { graphql } from 'gatsby'
 import styled from 'styled-components'
+
+// Utilities
+import { convertToOption, allCitiesOption } from '../utils'
 
 // Components
 import Layout from '../components/Layout'
@@ -11,19 +15,18 @@ import List from '../components/List'
 import Footer from '../components/Footer'
 
 // Index
-const IndexPage = () => {
-  const [currentCity, setCurrentCity] = useState({ value: 'all', label: 'All cities' })
+const IndexPage = ({ data: { city }, pageContext: { slug, country } }) => {
+  const isCityPage = !!(city && slug && country)
+  const currentCity = isCityPage ? convertToOption(city) : allCitiesOption
 
   return (
     <Layout>
       <Header>
         <Top />
-        <Map setCurrentCity={setCurrentCity} />
+        <Map />
       </Header>
       <Cta />
-      <List
-        currentCity={currentCity}
-        setCurrentCity={setCurrentCity} />
+      <List currentCity={currentCity} />
       <Footer />
     </Layout>
   )
@@ -33,6 +36,14 @@ const Header = styled.div`
   padding: 40px 0 0 0;
   background: ${p => p.theme.purple};
   @media screen and (min-width: 850px) { padding: 64px 0 0 0; }
+`
+
+export const query = graphql`
+  query($slug: String, $country: String) {
+    city: citiesJson(slug: { eq: $slug }, country: { eq: $country }){
+      slug, name, country
+    }
+  }
 `
 
 export default IndexPage

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,22 @@
+// using CommonJS because this is imported on gatsby-node.js
+// https://github.com/gatsbyjs/gatsby/issues/7810
+
+const { navigate } = require('gatsby')
+const { DO_NOT_SCROLL_KEY } = require('../gatsby-constants')
+
+const doNotScroll = () => window[DO_NOT_SCROLL_KEY] = true
+const createCityUrl = (countrySlug, citySlug) => `/${countrySlug}/${citySlug}`
+
+exports.createCityUrl = createCityUrl
+exports.navigateTo = (url, scrollTo) => {
+  if(scrollTo && typeof window !== 'undefined') window.scrollTo(scrollTo)
+  if(url) doNotScroll(navigate(url))
+}
+
+exports.convertToOption = ({ slug, name, country }) => ({
+  value: slug, label: name, data: { url: createCityUrl(country, slug) },
+})
+
+exports.allCitiesOption = { value: 'all', label: 'All cities', data: { url: '/' } }
+
+exports.unwrapNodes = data => data ? (data.edges || []).map(edge => edge.node) : []


### PR DESCRIPTION
closes #1. feedback wanted.
[deployed `preview`](https://deploy-preview-9--women-in-tech.netlify.com/)

## todo
- [x] create pages
- [x] link pages (in `<CityLink/>` inside of `<List/>`)
- [x] replace `<Map/>` dots with links
- [x] handle select change
- [ ] metadata: `<title/>` / `Helmet`/ custom `og:image`, etc

#### workarounds introduced (`gatsby-browser`)

by default `gatsby` manages the scroll state to emulate default browser behaviors.
I've had to undo some of them to keep the selection change smooth (without page jumps).

**PS**: sorry, totally forgot about [draft PR's](https://github.blog/2019-02-14-introducing-draft-pull-requests/), added a WIP prefix. `¯\_(ツ)_/¯`