### PR TITLE
Add Finland as country, Helsinki as city and five orgs

### DIFF
--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -154,6 +154,13 @@
     "left": 270
   },
   {
+    "name": "Helsinki",
+    "slug": "helsinki",
+    "country": "finland",
+    "top": 173,
+    "left": 513
+  },
+  {
     "name": "Indiana",
     "slug": "indiana",
     "country": "usa",

--- a/src/data/countries.json
+++ b/src/data/countries.json
@@ -56,6 +56,10 @@
     "name": "France"
   },
   {
+    "slug": "finland",
+    "name": "Finland"
+  },
+  {
     "slug": "germany",
     "name": "Germany"
   },

--- a/src/data/orgs/code-pub-helsinki.json
+++ b/src/data/orgs/code-pub-helsinki.json
@@ -1,0 +1,8 @@
+{
+  "image": "https://secure.meetupstatic.com/photos/event/b/a/7/b/600_468047739.jpeg",
+  "name": "Code Pub Helsinki",
+  "country": "finland",
+  "city": "helsinki",
+  "topics": ["Tech"],
+  "mainLink": "https://www.meetup.com/The-Code-Pub-Helsinki/"
+}

--- a/src/data/orgs/code-pub-stockholm.json
+++ b/src/data/orgs/code-pub-stockholm.json
@@ -1,0 +1,8 @@
+{
+  "image": "https://secure.meetupstatic.com/photos/theme_head/2/e/0/5/full_7331781.jpeg",
+  "name": "Code Pub Stockholm",
+  "country": "sweden",
+  "city": "stockholm",
+  "topics": ["Tech"],
+  "mainLink": "https://www.meetup.com/The-Code-Pub-Stockholm/"
+}

--- a/src/data/orgs/mimmit-koodaa-finland.json
+++ b/src/data/orgs/mimmit-koodaa-finland.json
@@ -1,0 +1,22 @@
+{
+  "image": "https://mimmitkoodaa.ohjelmistoebusiness.fi/wp-content/uploads/2019/05/sininen-pallo-logo-297x300.png",
+  "name": "Mimmit Koodaa",
+  "country": "finland",
+  "city": "helsinki",
+  "topics": ["Tech"],
+  "mainLink": "https://mimmitkoodaa.ohjelmistoebusiness.fi/",
+  "secondaryLinks": [
+    {
+      "name": "Twitter",
+      "url": "https://twitter.com/mimmitkoodaa"
+    },
+    {
+        "name": "Instagram",
+        "url": "https://www.instagram.com/mimmitkoodaa/"
+    },
+    {
+        "name": "Facebook",
+        "url": "https://www.facebook.com/mimmitkoodaa/"
+    }
+  ]
+}

--- a/src/data/orgs/pyladies-helsinki.json
+++ b/src/data/orgs/pyladies-helsinki.json
@@ -1,0 +1,18 @@
+{
+  "image": "https://res.cloudinary.com/toughbyte/image/upload/b_transparent,c_pad,g_center,h_230,w_230/v1445769771/ahmlwbzfpshaefihyal4.png",
+  "name": "PyLadies Helsinki",
+  "country": "finland",
+  "city": "helsinki",
+  "topics": ["Python"],
+  "mainLink": "https://www.meetup.com/Helsinki-PyLadies/",
+  "secondaryLinks": [
+    {
+      "name": "Twitter",
+      "url": "https://twitter.com/pyladieshki"
+    },
+    {
+        "name": "GitHub",
+        "url": "https://github.com/pyladieshki"
+    }
+  ]
+}

--- a/src/data/orgs/r-ladies-helsinki.json
+++ b/src/data/orgs/r-ladies-helsinki.json
@@ -1,0 +1,14 @@
+{
+  "city": "helsinki",
+  "country": "finland",
+  "name": "R-Ladies Helsinki",
+  "image": "https://pbs.twimg.com/profile_images/842033618226683905/ee4wjuxG_400x400.jpg",
+  "topics": ["R Programming, "],
+  "mainLink": "https://www.meetup.com/rladies-helsinki/",
+  "secondaryLinks": [
+    {
+      "name": "Twitter",
+      "url": "https://twitter.com/rladieshelsinki"
+    }
+  ]
+}


### PR DESCRIPTION
Add Finland to countries, Helsinki to cities and five orgs in total.

Four orgs to Helsinki:

- Mimmit Koodaa
- PyLadies Helsinki
- R Ladies Helsinki
- Code Pub Helsinki

And one org to Stockholm:
- Code Pub Stockholm