### PR TITLE
Add Turku.py organization to the list of orgs

### DIFF
--- a/src/data/cities.json
+++ b/src/data/cities.json
@@ -441,6 +441,13 @@
     "left": 496
   },
   {
+    "name": "Turku",
+    "slug": "turku",
+    "country": "finland",
+    "top": 175,
+    "left": 503
+  },
+  {
     "name": "Utah",
     "slug": "utah",
     "country": "usa",

--- a/src/data/orgs/turku-py.json
+++ b/src/data/orgs/turku-py.json
@@ -1,0 +1,18 @@
+{
+  "image": "https://turkupy.github.io/static/logo-e556aca72f8670e6571bdd474a461f90.png",
+  "name": "Turku.py",
+  "country": "finland",
+  "city": "turku",
+  "topics": ["Python", "Tech"],
+  "mainLink": "https://turkupy.github.io/",
+  "secondaryLinks": [
+    {
+      "name": "Twitter",
+      "url": "https://twitter.com/turku_py"
+    },
+    {
+      "name": "GitHub",
+      "url": "https://github.com/turkupy/turkupy.github.io"
+    }
+  ]
+}


### PR DESCRIPTION
Turku.py is a tech community for women and non-binaries based in Turku, Finland. I am one of the organizers, and during corona we've been doing some online events like reading circles, etc. so it'd be great to have our community on the women worldwide list! Our website is also open source and open for contributions. 