### PR TITLE
Pehia foundation logo updated

### DIFF
--- a/src/data/orgs/pehia.json
+++ b/src/data/orgs/pehia.json
@@ -1,5 +1,5 @@
 {
-  "image": "https://pbs.twimg.com/profile_images/993767204033196032/2YJz-Pdw_400x400.jpg",
+  "image": "https://user-images.githubusercontent.com/8397274/119461773-a99a4500-bd5d-11eb-93a9-222a39259b94.png",
   "name": "Pehia Foundation",
   "country": "india",
   "city": "kochi",


### PR DESCRIPTION
Pehia Logo URL is fixed with a static square logo url instead of the twitter cdn url.