### PR TITLE
Change prefetch font plugin

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: [
+    `gatsby-plugin-preload-fonts`,
     `gatsby-plugin-react-helmet`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
@@ -18,17 +19,6 @@ module.exports = {
         rule: {
           include: /svgs/
         }
-      }
-    },
-    {
-      resolve: `gatsby-plugin-prefetch-google-fonts`,
-      options: {
-        fonts: [
-          {
-            family: `Poppins`,
-            variants: [`500`, `600`]
-          }
-        ]
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Women World Wide Dev",
   "version": "0.1.0",
   "scripts": {
+    "preload-fonts": "gatsby-preload-fonts",
     "build": "gatsby build",
     "develop": "gatsby develop",
     "start": "npm run develop",
@@ -16,7 +17,7 @@
     "gatsby-image": "^2.0.30",
     "gatsby-plugin-manifest": "^2.0.20",
     "gatsby-plugin-offline": "^2.0.24",
-    "gatsby-plugin-prefetch-google-fonts": "^1.4.0",
+    "gatsby-plugin-preload-fonts": "^2.11.0",
     "gatsby-plugin-react-helmet": "^3.0.7",
     "gatsby-plugin-react-svg": "^2.0.0",
     "gatsby-plugin-sharp": "^2.0.23",


### PR DESCRIPTION
Change prefetch font plugin from:

    `gatsby-plugin-prefetch-google-fonts`

...to:

    `gatsby-plugin-preload-fonts`

...in order to avoid the error described here:

    https://github.com/gatsbyjs/gatsby/issues/27607